### PR TITLE
Fix path parsing and pointer casts in sync library

### DIFF
--- a/pCloudCC/lib/pclsync/psynclib.c
+++ b/pCloudCC/lib/pclsync/psynclib.c
@@ -2867,7 +2867,7 @@ char* get_pc_name() {
 }
 /***********************************************************************************************************************************************/
 void psync_async_delete_sync(void* ptr) {
-  psync_syncid_t syncId = (psync_syncid_t*)ptr;
+  psync_syncid_t syncId = *(psync_syncid_t*)ptr;
   int res;
 
   res = psync_delete_sync(syncId);
@@ -2880,7 +2880,7 @@ void psync_async_delete_sync(void* ptr) {
 }
 /***********************************************************************************************************************************************/
 void psync_async_ui_callback(void* ptr) {
-  int eventId = (int*)ptr;
+  int eventId = *(int*)ptr;
   time_t currTime = psync_time();
 
   if (((currTime - lastBupDelEventTime) > bupNotifDelay) || (lastBupDelEventTime == 0)) {
@@ -2896,7 +2896,7 @@ int psync_delete_sync_by_folderid(psync_folderid_t fId) {
   psync_sql_res* sqlRes;
   psync_uint_row row;
 
-  psync_syncid_t* syncId;
+  psync_syncid_t syncId;
   psync_syncid_t* syncIdT;
 
   sqlRes = psync_sql_query_nolock("SELECT id FROM syncfolder WHERE folderid = ?");
@@ -2915,7 +2915,7 @@ int psync_delete_sync_by_folderid(psync_folderid_t fId) {
   psync_sql_free_result(sqlRes);
 
   syncIdT = psync_new(psync_syncid_t);
-  syncIdT = syncId;
+  *syncIdT = syncId;
 
   psync_run_thread1("psync_async_sync_delete", psync_async_delete_sync, syncIdT);
 

--- a/pCloudCC/lib/pclsync/ptools.c
+++ b/pCloudCC/lib/pclsync/ptools.c
@@ -398,7 +398,7 @@ char* get_machine_name() {
   return psync_strdup(pcName);
 }
 /*************************************************************/
-void parse_os_path(char* path, folderPath* folders, char* delim, int mode) {
+void parse_os_path(char* path, folderPath* folders, char delim, int mode) {
   char fName[255];
   char* buff;
   int i = 0, j = 0, k = 0;
@@ -411,7 +411,7 @@ void parse_os_path(char* path, folderPath* folders, char* delim, int mode) {
     if (path[i] != delim) {
       if ((path[i] == ':') && (mode == 1)) {
         //In case we meet a ":" as in C:\ we set the name to Drive + the string before the ":"
-        fName[k] = NULL;
+      fName[k] = 0;
         buff = psync_strcat("Drive ", &fName, NULL);
         psync_strlcpy(fName, buff, strlen(buff)+1);
 

--- a/pCloudCC/lib/pclsync/ptools.h
+++ b/pCloudCC/lib/pclsync/ptools.h
@@ -38,18 +38,12 @@
 #define FOLDER_ID          "folderid"
 #define PARENT_FOLDER_NAME "parentname"
 
-//Parser delimeter symbols
+// Parser delimiter symbols
 #define DELIM_SEMICOLON ';'
 
 #if defined(P_OS_WINDOWS)
 #define DELIM_DIR   '\\'
-#endif
-
-#if defined(P_OS_LINUX)
-#define DELIM_DIR  '/'
-#endif
-
-#if defined(P_OS_MACOSX)
+#elif defined(P_OS_LINUX) || defined(P_OS_MACOSX)
 #define DELIM_DIR  '/'
 #endif
 
@@ -86,7 +80,7 @@ char* getMACaddr();
 /**********************************************************************************************************/
 char* get_machine_name();
 /**********************************************************************************************************/
-void parse_os_path(char* path, folderPath* folders, char* delim, int mode);
+void parse_os_path(char* path, folderPath* folders, char delim, int mode);
 /**********************************************************************************************************/
 void send_psyncs_event(const char* binapi,
                        const char* auth);


### PR DESCRIPTION
## Summary
- Correct delimiter macros and parse_os_path signature
- Fix pointer casts in async callbacks and sync deletion helper

## Testing
- `sudo apt-get install -y libudev-dev`
- `sudo apt-get install -y libfuse-dev`
- `make clean`
- `make fs`

------
https://chatgpt.com/codex/tasks/task_e_68af5195a570832f9d291663ab1dbb93