### PR TITLE
Fix const path interfaces in sync library

### DIFF
--- a/pCloudCC/lib/pclsync/pfolder.c
+++ b/pCloudCC/lib/pclsync/pfolder.c
@@ -879,7 +879,7 @@ typedef struct {
   psync_synctype_t synctype;
 } psync_tmp_folder_t;
 
-psync_folder_list_t *psync_list_get_list(char* syncTypes){
+psync_folder_list_t *psync_list_get_list(const char* syncTypes){
   psync_sql_res *res;
   psync_variant_row row;
   psync_tmp_folder_t *folders;

--- a/pCloudCC/lib/pclsync/pfolder.h
+++ b/pCloudCC/lib/pclsync/pfolder.h
@@ -56,7 +56,7 @@ pfolder_list_t *psync_list_remote_folder(psync_folderid_t folderid, psync_listty
 pfolder_list_t *psync_list_local_folder(const char *path, psync_listtype_t listtype) PSYNC_NONNULL(1);
 pentry_t *psync_folder_stat_path(const char *remotepath);
 
-psync_folder_list_t* psync_list_get_list(char* syncTypes);
+psync_folder_list_t* psync_list_get_list(const char* syncTypes);
 
 psync_folderid_t psync_wait_folder_in_local_db(psync_folderid_t folderid);
 

--- a/pCloudCC/lib/pclsync/ptools.c
+++ b/pCloudCC/lib/pclsync/ptools.c
@@ -10,6 +10,7 @@
 #include "string.h"
 #include "stdlib.h"
 #include "pnetlibs.h"
+#include <stdio.h>
 
 #if defined(P_OS_WINDOWS)
 #define _CRT_SECURE_NO_WARNINGS
@@ -398,7 +399,7 @@ char* get_machine_name() {
   return psync_strdup(pcName);
 }
 /*************************************************************/
-void parse_os_path(char* path, folderPath* folders, char delim, int mode) {
+void parse_os_path(const char* path, folderPath* folders, char delim, int mode) {
   char fName[255];
   char* buff;
   int i = 0, j = 0, k = 0;

--- a/pCloudCC/lib/pclsync/ptools.h
+++ b/pCloudCC/lib/pclsync/ptools.h
@@ -80,7 +80,7 @@ char* getMACaddr();
 /**********************************************************************************************************/
 char* get_machine_name();
 /**********************************************************************************************************/
-void parse_os_path(char* path, folderPath* folders, char delim, int mode);
+void parse_os_path(const char* path, folderPath* folders, char delim, int mode);
 /**********************************************************************************************************/
 void send_psyncs_event(const char* binapi,
                        const char* auth);


### PR DESCRIPTION
## Summary
- Accept const paths and char delimiters in path parsing helpers
- Allow const sync type strings in folder list retrieval
- Include `<stdio.h>` to declare `sprintf`

## Testing
- `make fs`

------
https://chatgpt.com/codex/tasks/task_e_68af5328a2ac832f93578ba72304c1f9