### PR TITLE
Add flag to disable device monitor when libudev missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@ This is a simple linux console client for pCloud cloud storage.
 Also requires   
 [CMake](https://cmake.org/) build system.  
 
-On Ubuntu you can run the following command:  
+On Ubuntu you can run the following command:
 > sudo apt-get install cmake zlib1g-dev libboost-system-dev libboost-program-options-dev libpthread-stubs0-dev libfuse-dev libudev-dev
+
+If `libudev-dev` is not available, the device monitor can be disabled by
+passing the `P_DEVMON_OFF=1` flag when building the sync library:
+
+> make fs P_DEVMON_OFF=1
 
 ## Build steps
 

--- a/pCloudCC/lib/pclsync/Makefile
+++ b/pCloudCC/lib/pclsync/Makefile
@@ -47,7 +47,13 @@ OBJ=pcompat.o psynclib.o plocks.o plibs.o pcallbacks.o pdiff.o pstatus.o papi.o 
      psyncer.o ptasks.o psettings.o pnetlibs.o pcache.o pscanner.o plist.o plocalscan.o plocalnotify.o pp2p.o\
      pcrypto.o pssl.o pfileops.o ptree.o ppassword.o prunratelimit.o pmemlock.o pnotifications.o pexternalstatus.o publiclinks.o\
      pbusinessaccount.o pcontacts.o poverlay.o poverlay_lin.o poverlay_mac.o poverlay_win.o pcompression.o pasyncnet.o ppathstatus.o\
-     pdevice_monitor.o ptools.o
+     ptools.o
+
+ifdef P_DEVMON_OFF
+CFLAGS += -DP_DEVMON_OFF
+else
+OBJ += pdevice_monitor.o
+endif
 
 OBJFS=pfs.o ppagecache.o pfsfolder.o pfstasks.o pfsupload.o pintervaltree.o pfsxattr.o pcloudcrypto.o pfscrypto.o pcrc32c.o pfsstatic.o plocks.o
 

--- a/pCloudCC/lib/pclsync/pdevice_monitor.h
+++ b/pCloudCC/lib/pclsync/pdevice_monitor.h
@@ -2,6 +2,9 @@
 
 #ifndef _PDEVICE_MONITOR
 #define _PDEVICE_MONITOR
+#ifdef P_DEVMON_OFF
+static inline void psync_devmon_init(void) {}
+#else
 #include <stdint.h>
 #include "psynclib.h"
 
@@ -34,5 +37,6 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+#endif /* P_DEVMON_OFF */
 
 #endif //_PDEVICE_MONITOR

--- a/pCloudCC/lib/pclsync/psynclib.c
+++ b/pCloudCC/lib/pclsync/psynclib.c
@@ -303,7 +303,9 @@ void psync_start_sync(pstatus_change_callback_t status_callback, pevent_callback
   psync_p2p_init();
   if (psync_setting_get_bool(_PS(autostartfs)))
     psync_fs_start();
+  #ifndef P_DEVMON_OFF
   psync_devmon_init();
+  #endif
 }
 
 void psync_set_notification_callback(pnotification_callback_t notification_callback, const char *thumbsize){


### PR DESCRIPTION
## Summary
- allow disabling device monitor with `P_DEVMON_OFF` build flag
- skip `pdevice_monitor.c` when flag set and guard runtime call
- document the flag in README

## Testing
- `make fs P_DEVMON_OFF=1` *(fails: fatal error: fuse.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af6507d42c832fa1751f084e83051a